### PR TITLE
Fix build configuration for GitHub Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ test-results
 /test-results
 *.spec.js.map
 /coverage
+.angular/

--- a/angular.json
+++ b/angular.json
@@ -80,5 +80,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,8 @@
     "test:coverage": "jest --coverage",
     "e2e": "playwright test --ui",
     "e2e:headless": "playwright test",
- copilot/fix-cb260cd0-e9f5-43c9-819f-ea0ef53a3483
     "e2e:cypress": "cypress open",
     "e2e:cypress:headless": "cypress run",
-
- main
     "lint": "eslint \"src/**/*.{ts,html}\"",
     "lint:fix": "eslint \"src/**/*.{ts,html}\" --fix",
     "format": "prettier --write \"src/**/*.{ts,html,css,scss,json}\"",


### PR DESCRIPTION
## Summary
- remove stray merge artifacts from package.json to restore valid scripts
- disable Angular CLI analytics prompts for non-interactive builds
- ignore the generated .angular cache directory to keep the repo clean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f956e6092483289aa4bfaedf0b1860